### PR TITLE
Starts the timer for mod keys only before updating the keystrokes list

### DIFF
--- a/packages/application/src/index.ts
+++ b/packages/application/src/index.ts
@@ -575,6 +575,9 @@ export class Application<T extends Widget = Widget> {
       case 'keydown':
         this.evtKeydown(event as KeyboardEvent);
         break;
+      case 'keyup':
+        this.evtKeyup(event as KeyboardEvent);
+        break;
       case 'contextmenu':
         this.evtContextMenu(event as PointerEvent);
         break;
@@ -610,6 +613,7 @@ export class Application<T extends Widget = Widget> {
   protected addEventListeners(): void {
     document.addEventListener('contextmenu', this);
     document.addEventListener('keydown', this, !this._bubblingKeydown);
+    document.addEventListener('keyup', this, !this._bubblingKeydown);
     window.addEventListener('resize', this);
   }
 
@@ -624,6 +628,19 @@ export class Application<T extends Widget = Widget> {
    */
   protected evtKeydown(event: KeyboardEvent): void {
     this.commands.processKeydownEvent(event);
+  }
+
+  /**
+   * A method invoked on a document `'keyup'` event.
+   *
+   * #### Notes
+   * The default implementation of this method invokes the key up
+   * processing method of the application command registry.
+   *
+   * A subclass may reimplement this method as needed.
+   */
+  protected evtKeyup(event: KeyboardEvent): void {
+    this.commands.processKeyupEvent(event);
   }
 
   /**


### PR DESCRIPTION
This PR should fix the timeout on modifier keys only with:
- if only modifiers are pressed:
  -  do not append them to the `_keystrokes` to avoid breaking sequences
  - start a dedicated timer (called `modifierTimer`) if the key(s) match a key binding, otherwise stop a potential existing timer
  - do not continue to process the `processKeydownEvent` method
- if any other key is pressed, stop the modifier timer
- if any key is released, stop the modifier timer
- when the modifier timer reaches the timeout, execute the appropriate command

It also restore the tests that should not be modified.